### PR TITLE
fix: add cross-links to Fae Realm in The Wandering Woods.md

### DIFF
--- a/Locations/The Wandering Woods.md
+++ b/Locations/The Wandering Woods.md
@@ -1,5 +1,9 @@
+---
+aliases: [Wandering Woods, The Wandering Forest]
+---
+
 # The Wandering Woods
 
 The Wandering Woods is a forest at the edge of the human kingdoms. Its defining feature is the transformation of its trails during traversal, ensnaring explorers and unlucky merchants in endless journeys.
 
-A prominent aspect of the forest's lore suggests that the Wandering Woods held an ancient pact with the fae, a bond woven into the very fabric of its existence. Believers claim that the trails can lead you in and out of the fae realm, though no one has returned to confirm this.
+A prominent aspect of the forest's lore suggests that the Wandering Woods held an ancient pact with the [fae](The%20Fae%20Realm.md), a bond woven into the very fabric of its existence. Believers claim that the trails can lead you in and out of the [fae realm](The%20Fae%20Realm.md), though no one has returned to confirm this.


### PR DESCRIPTION
Adds hyperlinks on fae and fae realm references pointing to The Fae Realm.md.