### PR TITLE
fix: normalize species frontmatter and mark stubs with status field

### DIFF
--- a/Species/Humanoid/Anguil.md
+++ b/Species/Humanoid/Anguil.md
@@ -1,5 +1,5 @@
 ---
-aliases: Anguils
+aliases: [Anguils]
 ---
 # Anguil
 

--- a/Species/Humanoid/Dwarf.md
+++ b/Species/Humanoid/Dwarf.md
@@ -1,3 +1,4 @@
 ---
-aliases: Dwarves
+aliases: [Dwarves]
+status: stub
 ---

--- a/Species/Humanoid/Elf.md
+++ b/Species/Humanoid/Elf.md
@@ -1,3 +1,4 @@
 ---
-aliases: Elves
+aliases: [Elves]
+status: stub
 ---

--- a/Species/Humanoid/Halfling.md
+++ b/Species/Humanoid/Halfling.md
@@ -1,3 +1,4 @@
 ---
-aliases: Halflings
+aliases: [Halflings]
+status: stub
 ---

--- a/Species/Humanoid/Human.md
+++ b/Species/Humanoid/Human.md
@@ -1,1 +1,5 @@
+---
+aliases: [Humans, Twicelings]
+status: stub
+---
 Jokingly referred to as "twicelings" by some Halflings.

--- a/Species/Humanoid/Orc.md
+++ b/Species/Humanoid/Orc.md
@@ -1,0 +1,4 @@
+---
+aliases: [Orcs]
+status: stub
+---


### PR DESCRIPTION
Normalizes aliases to YAML list syntax across all species. Adds status: stub to empty files. Adds frontmatter to Human.md and Orc.md.